### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Sling Media/SlingPlayer Desktop.install.recipe
+++ b/Sling Media/SlingPlayer Desktop.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>SlingPlayer Desktop.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Volitans Software/SMART Utility.download.recipe
+++ b/Volitans Software/SMART Utility.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SMART Utility.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.volitans-software.smartutility" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = YJ65CCRY6B)</string>
 			</dict>

--- a/Volitans Software/SMART Utility.install.recipe
+++ b/Volitans Software/SMART Utility.install.recipe
@@ -41,7 +41,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>SMART Utility.app</string>
 					</dict>
 				</array>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.