### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/CrystalMaker/CrystalDiffract.pkg.recipe
+++ b/CrystalMaker/CrystalDiffract.pkg.recipe
@@ -78,9 +78,9 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/CrystalMaker/CrystalMaker.pkg.recipe
+++ b/CrystalMaker/CrystalMaker.pkg.recipe
@@ -78,9 +78,9 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>

--- a/CrystalMaker/SingleCrystal.pkg.recipe
+++ b/CrystalMaker/SingleCrystal.pkg.recipe
@@ -78,9 +78,9 @@
 					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
+					<key>pkgname</key>
+					<string>%NAME%-%version%</string>
 				</dict>
-				<key>pkgname</key>
-				<string>%NAME%-%version%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCreator</string>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).