### PR TITLE
Deprecate SMARTUtility recipes

### DIFF
--- a/Volitans Software/SMART Utility.download.recipe
+++ b/Volitans Software/SMART Utility.download.recipe
@@ -20,6 +20,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the SMART Utility recipes in the flammable-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
This PR deprecates the non-functional SMART Utility recipes in this repo, and points users to working equivalents in the flammable-recipes repo.
