### PR TITLE
Update CrystalDiffract recipe for new zip download

### DIFF
--- a/CrystalMaker/CrystalDiffract.download.recipe
+++ b/CrystalMaker/CrystalDiffract.download.recipe
@@ -19,18 +19,37 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%.zip</string>
 				<key>url</key>
-				<string>http://www.crystalmaker.com/downloads/crystaldiffract_mac.dmg</string>
+				<string>https://crystalmaker.com/downloads/crystaldiffract7_mac.zip</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/CrystalDiffract.app</string>
+				<key>requirement</key>
+				<string>anchor apple generic and identifier "com.crystalmaker.crystaldiffract.v7" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = N6C85LN4R2)</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pathname%/CrystalDiffract.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/CrystalDiffract.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>
@@ -44,16 +63,12 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.dmg</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.zip</string>
 				<key>source_path</key>
 				<string>%pathname%</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/CrystalMaker/CrystalDiffract.pkg.recipe
+++ b/CrystalMaker/CrystalDiffract.pkg.recipe
@@ -18,72 +18,13 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>AppPkgCreator</string>
 			<key>Arguments</key>
 			<dict>
-				<key>info_path</key>
-				<string>%pathname%/CrystalDiffract.app</string>
-				<key>plist_keys</key>
-				<dict>
-					<key>CFBundleShortVersionString</key>
-					<string>version</string>
-				</dict>
+				<key>app_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/CrystalDiffract.app</string>
 			</dict>
-			<key>Processor</key>
-			<string>PlistReader</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkgdirs</key>
-				<dict>
-					<key>Applications</key>
-					<string>0775</string>
-				</dict>
-				<key>pkgroot</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
-			</dict>
-			<key>Processor</key>
-			<string>PkgRootCreator</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%pkgroot%/Applications/CrystalDiffract.app</string>
-				<key>source_path</key>
-				<string>%pathname%/CrystalDiffract.app</string>
-			</dict>
-			<key>Processor</key>
-			<string>Copier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>pkg_request</key>
-				<dict>
-					<key>chown</key>
-					<array>
-						<dict>
-							<key>group</key>
-							<string>admin</string>
-							<key>path</key>
-							<string>Applications</string>
-							<key>user</key>
-							<string>root</string>
-						</dict>
-					</array>
-					<key>id</key>
-					<string>com.CrystalDiffract.CrystalDiffract.pkg</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
-					<key>pkgdir</key>
-					<string>%RECIPE_CACHE_DIR%</string>
-					<key>pkgname</key>
-					<string>%NAME%-%version%</string>
-				</dict>
-			</dict>
-			<key>Processor</key>
-			<string>PkgCreator</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
This PR updates the CrystalDiffract recipes for the new zip download format, and adds code signature verification.

Verbose recipe run output:

```
% autopkg run -vvq CrystalDiffract.{download,pkg}.recipe
Processing CrystalDiffract.download.recipe...
WARNING: CrystalDiffract.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'CrystalDiffract.zip',
           'url': 'https://crystalmaker.com/downloads/crystaldiffract7_mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 06 Nov 2024 10:03:28 GMT
URLDownloader: Storing new ETag header: "b590536-6263ba1199c00"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/downloads/CrystalDiffract.zip
{'Output': {'download_changed': True,
            'etag': '"b590536-6263ba1199c00"',
            'last_modified': 'Wed, 06 Nov 2024 10:03:28 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/downloads/CrystalDiffract.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/downloads/CrystalDiffract.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename CrystalDiffract.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/downloads/CrystalDiffract.zip to ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/CrystalDiffract
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/CrystalDiffract/CrystalDiffract.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.crystalmaker.crystaldiffract.v7" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'N6C85LN4R2)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/CrystalDiffract/CrystalDiffract.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/CrystalDiffract/CrystalDiffract.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/CrystalDiffract/CrystalDiffract.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PlistReader
{'Input': {'info_path': '~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/CrystalDiffract/CrystalDiffract.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/CrystalDiffract/CrystalDiffract.app/Contents/Info.plist
PlistReader: Assigning value of '7.0.4' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '7.0.4'}}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/CrystalDiffract-7.0.4.zip',
           'source_path': '~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/downloads/CrystalDiffract.zip'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/downloads/CrystalDiffract.zip, dmg: , dmg_source_path:
Copier: Copied ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/downloads/CrystalDiffract.zip to ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/CrystalDiffract-7.0.4.zip
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/receipts/CrystalDiffract.download-receipt-20241227-173637.plist
Processing CrystalDiffract.pkg.recipe...
WARNING: CrystalDiffract.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
{'Input': {'filename': 'CrystalDiffract.zip',
           'url': 'https://crystalmaker.com/downloads/crystaldiffract7_mac.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 06 Nov 2024 10:03:28 GMT
URLDownloader: Storing new ETag header: "b590536-6263ba1199c00"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/downloads/CrystalDiffract.zip
{'Output': {'download_changed': True,
            'etag': '"b590536-6263ba1199c00"',
            'last_modified': 'Wed, 06 Nov 2024 10:03:28 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/downloads/CrystalDiffract.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/downloads/CrystalDiffract.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename CrystalDiffract.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/downloads/CrystalDiffract.zip to ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract/CrystalDiffract.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.crystalmaker.crystaldiffract.v7" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'N6C85LN4R2)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract/CrystalDiffract.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract/CrystalDiffract.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract/CrystalDiffract.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
PlistReader
{'Input': {'info_path': '~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract/CrystalDiffract.app/Contents/Info.plist',
           'plist_keys': {'CFBundleShortVersionString': 'version'}}}
PlistReader: Reading: ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract/CrystalDiffract.app/Contents/Info.plist
PlistReader: Assigning value of '7.0.4' to output variable 'version'
{'Output': {'plist_reader_output_variables': {'version': '7.0.4'}}}
Copier
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract-7.0.4.zip',
           'source_path': '~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/downloads/CrystalDiffract.zip'}}
Copier: Parsed dmg results: dmg_path: ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/downloads/CrystalDiffract.zip, dmg: , dmg_source_path:
Copier: Copied ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/downloads/CrystalDiffract.zip to ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract-7.0.4.zip
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract/CrystalDiffract.app',
           'version': '7.0.4'}}
AppPkgCreator: BundleID: com.crystalmaker.crystaldiffract.v7
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract/CrystalDiffract.app to ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/payload/Applications/CrystalDiffract.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.crystalmaker.crystaldiffract.v7',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract-7.0.4.pkg',
                                                        'version': '7.0.4'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '7.0.4'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/receipts/CrystalDiffract.pkg-receipt-20241227-173817.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.patgmac.download.CrystalDiffract/downloads/CrystalDiffract.zip
    ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/downloads/CrystalDiffract.zip

The following packages were built:
    Identifier                           Version  Pkg Path
    ----------                           -------  --------
    com.crystalmaker.crystaldiffract.v7  7.0.4    ~/Library/AutoPkg/Cache/com.github.patgmac.pkg.CrystalDiffract/CrystalDiffract-7.0.4.pkg
```
