### PR TITLE
Verify Adobe Acrobat updater package authority chain

### DIFF
--- a/AdobeAcrobatDC/AdobeAcrobatDCUnifiedUpdater.download.recipe
+++ b/AdobeAcrobatDC/AdobeAcrobatDCUnifiedUpdater.download.recipe
@@ -75,8 +75,12 @@ the current release notes page.</string>
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/AcrobatSCADCUpd%match%.pkg</string>
-				<key>requirement</key>
-				<string>anchor apple generic and certificate leaf[subject.OU] = "JQ525L2MZD"</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: Adobe Inc. (JQ525L2MZD)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
The recipe passed a designated `requirement` string to `CodeSignatureVerifier`. That argument is not consulted when verifying an installer package, so the signing identity was never checked. This switches to an `expected_authority_names` array (`Developer ID Installer: Adobe Inc. (JQ525L2MZD)` → `Developer ID Certification Authority` → `Apple Root CA`), validating the package's authority chain.

## Verification

`autopkg run -vv` — the change to the `CodeSignatureVerifier` output (before → after):

`% autopkg run -vv com.github.patgmac-recipes.download.AdobeAcrobatDCUnifiedUpdater`

```diff
--- before
+++ after
@@ -1,7 +1,9 @@
 CodeSignatureVerifier
-{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.patgmac-recipes.download.AdobeAcrobatDCUnifiedUpdater/AcrobatSCADCUpd2600121651.pkg',
-           'requirement': 'anchor apple generic and certificate '
-                          'leaf[subject.OU] = "JQ525L2MZD"'}}
+{'Input': {'expected_authority_names': ['Developer ID Installer: Adobe Inc. '
+                                        '(JQ525L2MZD)',
+                                        'Developer ID Certification Authority',
+                                        'Apple Root CA'],
+           'input_path': '~/Library/AutoPkg/Cache/com.github.patgmac-recipes.download.AdobeAcrobatDCUnifiedUpdater/AcrobatSCADCUpd2600121651.pkg'}}
 CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
 CodeSignatureVerifier: Verifying installer package signature...
 CodeSignatureVerifier: Package "AcrobatSCADCUpd2600121651.pkg":
@@ -28,4 +30,5 @@
 CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
 CodeSignatureVerifier: 
 CodeSignatureVerifier: Signature is valid
+CodeSignatureVerifier: Authority name chain is valid
 {'Output': {}}
```
